### PR TITLE
update build instructions and sync with cmake api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ file(GLOB SOURCES source/*.c*)
 
 add_executable(ps4_openorbis_test ${SOURCES})
 add_self(ps4_openorbis_test)
-add_pkg(ps4_openorbis_test "PACB00001" "pacbrew openorbis test" "01.00")
+add_pkg(ps4_openorbis_test pkgdir "PACB00001" "pacbrew openorbis test" "01.00")
 
 target_link_libraries(ps4_openorbis_test
         SceSysUtil

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 - Build
     - `mkdir build && cd build`
     - `source /opt/pacbrew/ps4/openorbis/ps4vars.sh`
-    - `orbis-cmake -G "Unix Makefiles" ../`
+    - `openorbis-cmake -G "Unix Makefiles" ../`
     - `make ps4_openorbis_test_pkg`


### PR DESCRIPTION
Note that on ubuntu, I cannot get PkgTool.Core to work:

```
A fatal error occurred. The required library libhostfxr.so could not be found.
If this is a self-contained application, that library should exist in [/opt/pacbrew/ps4/openorbis/bin/linux/].
If this is a framework-dependent application, install the runtime in the global location [/usr/share/dotnet] or use the DOTNET_ROOT environment variable to specify the runtime location or register the runtime location in [/etc/dotnet/install_location]
```

The binary included with openorbis-0.5.2 release works though:
```
/opt/openorbis-0.5.2/bin/linux/PkgTool.Core
Usage: PkgTool.Core <verb> [options ...]
...
```